### PR TITLE
Adding Multi-Target Support

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
@@ -33,7 +35,7 @@ func main() {
 			"web.config",
 			"[EXPERIMENTAL] Path to config yaml file that can enable TLS or authentication.",
 		).Default("").String()
-		rtpEnable = kingpin.Flag("rtp.enable", "enable rtp info, default: fasle").Default("false").Bool()
+		rtpEnable = kingpin.Flag("rtp.enable", "enable rtp info, default: false").Default("false").Bool()
 	)
 	promlogConfig := &promlog.Config{}
 	kingpin.Version("freeswitch_exporter")
@@ -49,6 +51,35 @@ func main() {
 	prometheus.MustRegister(c)
 
 	http.Handle(*metricsPath, promhttp.Handler())
+
+	// This implements Prometheus' multi-target exporter support
+	// Example project: Official Blackbox Exporter
+	// https://github.com/prometheus/blackbox_exporter#prometheus-configuration
+	http.HandleFunc("/probe", func(w http.ResponseWriter, r *http.Request) {
+		target := r.URL.Query().Get("target")
+		if target == "" {
+			http.Error(w, "'target' query param not provided, but required.", http.StatusBadRequest)
+
+		}
+
+		// Not checking for the port to allow the port to be configured in
+		// the Prometheus scrape target config.
+		if !strings.HasPrefix(target, "tcp://") {
+			target = fmt.Sprintf("tcp://%s", target)
+		}
+
+		c, colErr := NewCollector(target, *timeout, *password, *rtpEnable)
+		if colErr != nil {
+			http.Error(w, fmt.Sprintf("failed to create collector for %s: %s", target, colErr), http.StatusInternalServerError)
+		}
+
+		registry := prometheus.NewRegistry()
+		registry.MustRegister(c)
+
+		promhttp.HandlerFor(registry, promhttp.HandlerOpts{}).ServeHTTP(w, r)
+
+	})
+
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`<html>
 			<head><title>FreeSWITCH Exporter</title></head>


### PR DESCRIPTION
We are simply looking to simplify a couple things with our use case, which benefits greatly from being able to use Prometheus' multi-target config option.

I've added some notes to the README to include an example config. Tried to include references where I had them.

In some quick testing, I've had this running against 3-6 nodes without much of an issue, all reporting as expected.