### PR TITLE
Adding Gateway Status to freeswitch_sofia_gateway_status metric

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -423,7 +423,7 @@ func (c *Collector) sofiaStatusMetrics(ch chan<- prometheus.Metric) error {
 		}
 		level.Debug(logger).Log("sofia ", gateway.Name, " status:", status)
 		fs_status, err := prometheus.NewConstMetric(
-			prometheus.NewDesc(namespace+"_sofia_gateway_status", "freeswitch gateways status", nil, prometheus.Labels{"name": gateway.Name, "proxy": gateway.Proxy, "profile": gateway.Profile, "context": gateway.Context, "scheme": gateway.Scheme}),
+			prometheus.NewDesc(namespace+"_sofia_gateway_status", "freeswitch gateways status", nil, prometheus.Labels{"name": gateway.Name, "proxy": gateway.Proxy, "profile": gateway.Profile, "context": gateway.Context, "scheme": gateway.Scheme, "status": gateway.Status}),
 			prometheus.GaugeValue,
 			float64(status),
 		)


### PR DESCRIPTION
Adding the field "Status" to the freeswitch_sofia_gateway_status metric, I believe this is relevant for alerting purposes, i.e, in case one of the gateways is in "FAIL_WAIT" status, some actions might need to be taken.

If there's another way of doing this please share, any help is appreciated.