### PR TITLE
Add log.level argument

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -17,9 +17,9 @@ import (
 	"sync"
 	"time"
 
+	kitlog "github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/promlog"
 	"golang.org/x/net/html/charset"
 )
 
@@ -30,6 +30,7 @@ type Collector struct {
 	Timeout   time.Duration
 	Password  string
 	rtpEnable bool
+	logger    kitlog.Logger
 
 	conn  net.Conn
 	input *bufio.Reader
@@ -213,13 +214,17 @@ var (
 )
 
 // NewCollector processes uri, timeout and methods and returns a new Collector.
-func NewCollector(uri string, timeout time.Duration, password string, rtpEnable bool) (*Collector, error) {
+func NewCollector(uri string, timeout time.Duration, password string, rtpEnable bool, logger kitlog.Logger) (*Collector, error) {
 	var c Collector
 
 	c.URI = uri
 	c.Timeout = timeout
 	c.Password = password
 	c.rtpEnable = rtpEnable
+	if logger == nil {
+		logger = kitlog.NewNopLogger()
+	}
+	c.logger = logger
 
 	var url *url.URL
 	var err error
@@ -357,8 +362,6 @@ func (c *Collector) scapeMetrics(ch chan<- prometheus.Metric) error {
 }
 
 func (c *Collector) loadModuleMetrics(ch chan<- prometheus.Metric) error {
-	promlogConfig := &promlog.Config{}
-	logger := promlog.New(promlogConfig)
 	response, err := c.fsCommand("api xml_locate configuration configuration name modules.conf")
 
 	if err != nil {
@@ -372,7 +375,7 @@ func (c *Collector) loadModuleMetrics(ch chan<- prometheus.Metric) error {
 	if err != nil {
 		log.Println("loadModuleMetrics error: &cfgs", err)
 	}
-	level.Debug(logger).Log("[response]:", &cfgs)
+	level.Debug(c.logger).Log("[response]:", &cfgs)
 	fsLoadModules := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "freeswitch_load_module",
@@ -394,7 +397,7 @@ func (c *Collector) loadModuleMetrics(ch chan<- prometheus.Metric) error {
 		if string(status) == "true" {
 			load_mudule = 1
 		}
-		level.Debug(logger).Log("module", m.Module, " load status: ", string(status))
+		level.Debug(c.logger).Log("module", m.Module, "loadstatus:", string(status))
 		fsLoadModules.WithLabelValues(m.Module).Set(float64(load_mudule))
 	}
 	fsLoadModules.MetricVec.Collect(ch)
@@ -402,8 +405,6 @@ func (c *Collector) loadModuleMetrics(ch chan<- prometheus.Metric) error {
 }
 
 func (c *Collector) sofiaStatusMetrics(ch chan<- prometheus.Metric) error {
-	promlogConfig := &promlog.Config{}
-	logger := promlog.New(promlogConfig)
 	response, err := c.fsCommand("api sofia xmlstatus gateway")
 
 	if err != nil {
@@ -418,13 +419,13 @@ func (c *Collector) sofiaStatusMetrics(ch chan<- prometheus.Metric) error {
 	if err != nil {
 		log.Println("sofiaStatusMetrics error: &gw", err)
 	}
-	level.Debug(logger).Log("[response]:", &gw)
+	level.Debug(c.logger).Log("[response]:", &gw)
 	for _, gateway := range gw.Gateway {
 		status := 0
 		if gateway.Status == "UP" {
 			status = 1
 		}
-		level.Debug(logger).Log("sofia ", gateway.Name, " status:", status)
+		level.Debug(c.logger).Log("sofia", gateway.Name, "status:", status)
 		fs_status, err := prometheus.NewConstMetric(
 			prometheus.NewDesc(namespace+"_sofia_gateway_status", "freeswitch gateways status", nil, prometheus.Labels{"name": gateway.Name, "proxy": gateway.Proxy, "profile": gateway.Profile, "context": gateway.Context, "scheme": gateway.Scheme, "status": gateway.Status}),
 			prometheus.GaugeValue,
@@ -551,8 +552,6 @@ func (c *Collector) sofiaStatusMetrics(ch chan<- prometheus.Metric) error {
 }
 
 func (c *Collector) memoryMetrics(ch chan<- prometheus.Metric) error {
-	promlogConfig := &promlog.Config{}
-	logger := promlog.New(promlogConfig)
 	response, err := c.fsCommand("api memory")
 	if err != nil {
 		return err
@@ -570,7 +569,7 @@ func (c *Collector) memoryMetrics(ch chan<- prometheus.Metric) error {
 		matches := regexp.MustCompile(`(.+?) \((.+?)\):\s+(\d+)`).FindStringSubmatch(line)
 
 		if matches == nil {
-			level.Debug(logger).Log("msg", "Cannot parse memory line", "line", line)
+			level.Debug(c.logger).Log("msg", "cannot parse memory line", "line", line)
 			continue
 		}
 
@@ -599,8 +598,6 @@ func (c *Collector) memoryMetrics(ch chan<- prometheus.Metric) error {
 }
 
 func (c *Collector) endpointMetrics(ch chan<- prometheus.Metric) error {
-	promlogConfig := &promlog.Config{}
-	logger := promlog.New(promlogConfig)
 	response, err := c.fsCommand("api show endpoint as xml")
 
 	if err != nil {
@@ -613,7 +610,7 @@ func (c *Collector) endpointMetrics(ch chan<- prometheus.Metric) error {
 	if err != nil {
 		log.Println("endpointMetrics error: &rt", err)
 	}
-	level.Debug(logger).Log("[response]:", &rt)
+	level.Debug(c.logger).Log("[response]:", &rt)
 	for _, ep := range rt.Row {
 		ep_load, err := prometheus.NewConstMetric(
 			prometheus.NewDesc(namespace+"_endpoint_status", "freeswitch endpoint status", nil, prometheus.Labels{"type": ep.Type.Text, "name": ep.Name.Text, "ikey": ep.Ikey.Text}),
@@ -631,8 +628,6 @@ func (c *Collector) endpointMetrics(ch chan<- prometheus.Metric) error {
 }
 
 func (c *Collector) registrationsMetrics(ch chan<- prometheus.Metric) error {
-	promlogConfig := &promlog.Config{}
-	logger := promlog.New(promlogConfig)
 	response, err := c.fsCommand("api show registrations as xml")
 
 	if err != nil {
@@ -645,7 +640,7 @@ func (c *Collector) registrationsMetrics(ch chan<- prometheus.Metric) error {
 	if err != nil {
 		log.Println("registrationsMetrics error: &rt", err)
 	}
-	level.Debug(logger).Log("[response]:", &rt)
+	level.Debug(c.logger).Log("[response]:", &rt)
 	for _, cc := range rt.Row {
 		cc_load, err := prometheus.NewConstMetric(
 			prometheus.NewDesc(namespace+"_registration_defails", "freeswitch registration status", nil, prometheus.Labels{"reg_user": cc.RegUser.Text, "hostname": cc.Hostname.Text, "realm": cc.Realm.Text, "token": cc.Token.Text, "url": cc.Url.Text, "expires": cc.Expires.Text, "network_ip": cc.NetworkIp.Text, "network_port": cc.NetworkPort.Text, "network_proto": cc.NetworkProto.Text}),
@@ -663,8 +658,6 @@ func (c *Collector) registrationsMetrics(ch chan<- prometheus.Metric) error {
 }
 
 func (c *Collector) codecMetrics(ch chan<- prometheus.Metric) error {
-	promlogConfig := &promlog.Config{}
-	logger := promlog.New(promlogConfig)
 	response, err := c.fsCommand("api show codec as xml")
 
 	if err != nil {
@@ -677,7 +670,7 @@ func (c *Collector) codecMetrics(ch chan<- prometheus.Metric) error {
 	if err != nil {
 		log.Println("codecMetrics error: &rt", err)
 	}
-	level.Debug(logger).Log("[response]:", &rt)
+	level.Debug(c.logger).Log("[response]:", &rt)
 	for _, cc := range rt.Row {
 		cc_load, err := prometheus.NewConstMetric(
 			prometheus.NewDesc(namespace+"_codec_status", "freeswitch endpoint status", nil, prometheus.Labels{"type": cc.Type.Text, "name": cc.Name.Text, "ikey": cc.Ikey.Text}),
@@ -695,8 +688,6 @@ func (c *Collector) codecMetrics(ch chan<- prometheus.Metric) error {
 }
 
 func (c *Collector) vertoMetrics(ch chan<- prometheus.Metric) error {
-	promlogConfig := &promlog.Config{}
-	logger := promlog.New(promlogConfig)
 	response, err := c.fsCommand("api verto xmlstatus")
 
 	if err != nil {
@@ -709,7 +700,7 @@ func (c *Collector) vertoMetrics(ch chan<- prometheus.Metric) error {
 	if err != nil {
 		log.Println("vertoMetrics error: &rt", err)
 	}
-	level.Debug(logger).Log("[response]:", &vt)
+	level.Debug(c.logger).Log("[response]:", &vt)
 	for _, cc := range vt.Profile {
 		vt_status := 0
 		if cc.State.Text == "RUNNING" {

--- a/main.go
+++ b/main.go
@@ -16,6 +16,10 @@ import (
 
 func main() {
 	var (
+		logLevel = kingpin.Flag(
+			"log.level",
+			"Log level for structured logging (debug, info, warn, error).",
+		).Default("debug").Enum("debug", "info", "warn", "error")
 		listenAddress = kingpin.Flag(
 			"web.listen-address",
 			"Address to listen on for web interface and telemetry.").Short('l').Default(":9282").String()
@@ -37,10 +41,14 @@ func main() {
 		).Default("").String()
 		rtpEnable = kingpin.Flag("rtp.enable", "enable rtp info(feature:todo!), default: fasle").Default("false").Bool()
 	)
-	promlogConfig := &promlog.Config{}
 	kingpin.Version("freeswitch_exporter\nversion: 1.0.6")
-	logger := promlog.New(promlogConfig)
 	kingpin.Parse()
+
+	promlogConfig := &promlog.Config{}
+	if err := promlogConfig.Level.Set(*logLevel); err != nil {
+		panic(fmt.Sprintf("invalid log level %q: %v", *logLevel, err))
+	}
+	logger := promlog.New(promlogConfig)
 
 	c, err := NewCollector(*scrapeURI, *timeout, *password, *rtpEnable)
 

--- a/main.go
+++ b/main.go
@@ -45,12 +45,14 @@ func main() {
 	kingpin.Parse()
 
 	promlogConfig := &promlog.Config{}
+	promlogConfig.Level = &promlog.AllowedLevel{}   // ensure level flag has a target
+	promlogConfig.Format = &promlog.AllowedFormat{} // keep format configurable
 	if err := promlogConfig.Level.Set(*logLevel); err != nil {
 		panic(fmt.Sprintf("invalid log level %q: %v", *logLevel, err))
 	}
 	logger := promlog.New(promlogConfig)
 
-	c, err := NewCollector(*scrapeURI, *timeout, *password, *rtpEnable)
+	c, err := NewCollector(*scrapeURI, *timeout, *password, *rtpEnable, logger)
 
 	if err != nil {
 		panic(err)
@@ -76,7 +78,7 @@ func main() {
 			target = fmt.Sprintf("tcp://%s", target)
 		}
 
-		c, colErr := NewCollector(target, *timeout, *password, *rtpEnable)
+		c, colErr := NewCollector(target, *timeout, *password, *rtpEnable, logger)
 		if colErr != nil {
 			http.Error(w, fmt.Sprintf("failed to create collector for %s: %s", target, colErr), http.StatusInternalServerError)
 		}


### PR DESCRIPTION
Thanks for building this exporter @mroject :) , it's super handy.

I have freeswitch_exporter running in systemd on debian 12, so having log level as debug spews out too many logs to journald/syslog. 

This PR adds `--log.level` argument to set the "allowed" log level for promlog. I also had to pass `main.go`'s logger into `collector.go`, to ensure log level is applied over everything. 

e.g. 
<img width="1037" height="235" alt="image" src="https://github.com/user-attachments/assets/1c36f568-adce-4386-a231-6b8e286d9889" />
