### PR TITLE
feat: add freeswitch_channel_duration_seconds histogram

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ Flags:
                                Password for freeswitch event socket.
       --web.config=""          [EXPERIMENTAL] Path to config yaml file that can
                                enable TLS or authentication.
+      --freeswitch.channel-duration.enable
+                               Enable the freeswitch_channel_duration_seconds
+                               histogram of active channel ages. (default: true)
+      --freeswitch.channel-duration.buckets="30,60,120,300,600,900,1800,3600,7200,14400,21600,43200,86400,172800"
+                               Comma-separated histogram bucket upper bounds
+                               (seconds) for freeswitch_channel_duration_seconds.
       --version                Show application version.
 ```
 
@@ -215,6 +221,43 @@ List of exposed metrics:
 # TYPE freeswitch_memory_uordblks gauge
 # HELP freeswitch_memory_usmblks Max. total allocated space
 # TYPE freeswitch_memory_usmblks gauge
+# HELP freeswitch_channel_duration_seconds Age of currently active FreeSWITCH channels in seconds, observed at scrape time.
+# TYPE freeswitch_channel_duration_seconds histogram
+```
+
+### Channel duration histogram (zombie channel detection)
+
+`freeswitch_channel_duration_seconds` is a histogram of **active channel age in seconds, observed at scrape time**. It is fetched via `api show channels as json` and rebuilt fresh on every scrape (it does not accumulate across scrapes). It is enabled by default; disable it with `--freeswitch.channel-duration.enable=false`, which also skips issuing the underlying command.
+
+Default bucket upper bounds (seconds), chosen to include explicit zombie-channel thresholds at 6h/12h/24h:
+
+```
+30, 60, 120, 300, 600, 900, 1800, 3600, 7200, 14400, 21600 (6h), 43200 (12h), 86400 (24h), 172800
+```
+
+Override with `--freeswitch.channel-duration.buckets`, a comma-separated, strictly increasing list of positive values (e.g. `--freeswitch.channel-duration.buckets=30,60,300`). An invalid list (non-numeric, `<= 0`, or not strictly increasing) causes the exporter to fail at startup with an error naming the offending value.
+
+Example output:
+
+```
+# HELP freeswitch_channel_duration_seconds Age of currently active FreeSWITCH channels in seconds, observed at scrape time.
+# TYPE freeswitch_channel_duration_seconds histogram
+freeswitch_channel_duration_seconds_bucket{le="30"} 0
+freeswitch_channel_duration_seconds_bucket{le="60"} 0
+freeswitch_channel_duration_seconds_bucket{le="21600"} 3
+freeswitch_channel_duration_seconds_bucket{le="43200"} 4
+freeswitch_channel_duration_seconds_bucket{le="86400"} 5
+freeswitch_channel_duration_seconds_bucket{le="+Inf"} 5
+freeswitch_channel_duration_seconds_sum 432000
+freeswitch_channel_duration_seconds_count 5
+```
+
+Number of channels older than 6h/12h/24h can be computed with PromQL:
+
+```
+freeswitch_channel_duration_seconds_count - freeswitch_channel_duration_seconds_bucket{le="21600"}  # older than 6h
+freeswitch_channel_duration_seconds_count - freeswitch_channel_duration_seconds_bucket{le="43200"}  # older than 12h
+freeswitch_channel_duration_seconds_count - freeswitch_channel_duration_seconds_bucket{le="86400"}  # older than 24h
 ```
 
 ## Compiling

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ List of exposed metrics:
 
 ### Channel duration histogram (zombie channel detection)
 
-`freeswitch_channel_duration_seconds` is a histogram of **active channel age in seconds, observed at scrape time**. It is fetched via `api show channels as json` and rebuilt fresh on every scrape (it does not accumulate across scrapes). It is enabled by default; disable it with `--freeswitch.channel-duration.enable=false`, which also skips issuing the underlying command.
+`freeswitch_channel_duration_seconds` is a histogram of **active channel age in seconds, observed at scrape time**. It is fetched via `api show channels as json` and rebuilt fresh on every scrape (it does not accumulate across scrapes). It is enabled by default; disable it with `--no-freeswitch.channel-duration.enable`, which also skips issuing the underlying command.
 
 Default bucket upper bounds (seconds), chosen to include explicit zombie-channel thresholds at 6h/12h/24h:
 

--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ Flags:
                                Password for freeswitch event socket.
       --web.config=""          [EXPERIMENTAL] Path to config yaml file that can
                                enable TLS or authentication.
-      --freeswitch.channel-duration.enable
-                               Enable the freeswitch_channel_duration_seconds
-                               histogram of active channel ages. (default: true)
+      --freeswitch.channel-duration.disable
+                               Disable the freeswitch_channel_duration_seconds
+                               histogram of active channel ages. (default: false)
       --freeswitch.channel-duration.buckets="30,60,120,300,600,900,1800,3600,7200,14400,21600,43200,86400,172800"
                                Comma-separated histogram bucket upper bounds
                                (seconds) for freeswitch_channel_duration_seconds.
@@ -227,7 +227,7 @@ List of exposed metrics:
 
 ### Channel duration histogram (zombie channel detection)
 
-`freeswitch_channel_duration_seconds` is a histogram of **active channel age in seconds, observed at scrape time**. It is fetched via `api show channels as json` and rebuilt fresh on every scrape (it does not accumulate across scrapes). It is enabled by default; disable it with `--no-freeswitch.channel-duration.enable`, which also skips issuing the underlying command.
+`freeswitch_channel_duration_seconds` is a histogram of **active channel age in seconds, observed at scrape time**. It is fetched via `api show channels as json` and rebuilt fresh on every scrape (it does not accumulate across scrapes). It is enabled by default; disable it with `--freeswitch.channel-duration.disable`, which also skips issuing the underlying command.
 
 Default bucket upper bounds (seconds), chosen to include explicit zombie-channel thresholds at 6h/12h/24h:
 

--- a/channel_duration.go
+++ b/channel_duration.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // parseBuckets parses a comma-separated list of histogram bucket upper bounds.
@@ -51,4 +53,43 @@ func parseCreatedEpoch(s string) (time.Time, error) {
 	}
 
 	return time.Unix(v, 0), nil
+}
+
+// buildChannelDurationHistogram builds a histogram of active channel ages (in seconds).
+// Skips rows with invalid created_epoch and clamps negative ages to 0.
+func buildChannelDurationHistogram(rows []map[string]any, now time.Time, buckets []float64) (prometheus.Histogram, int) {
+	histogram := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: namespace,
+		Name:      "channel_duration_seconds",
+		Help:      "Age of currently active FreeSWITCH channels in seconds, observed at scrape time.",
+		Buckets:   buckets,
+	})
+
+	skipped := 0
+
+	for _, row := range rows {
+		raw, ok := row["created_epoch"].(string)
+
+		if !ok {
+			skipped++
+			continue
+		}
+
+		start, err := parseCreatedEpoch(raw)
+
+		if err != nil {
+			skipped++
+			continue
+		}
+
+		age := now.Sub(start).Seconds()
+
+		if age < 0 {
+			age = 0
+		}
+
+		histogram.Observe(age)
+	}
+
+	return histogram, skipped
 }

--- a/channel_duration.go
+++ b/channel_duration.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // parseBuckets parses a comma-separated list of histogram bucket upper bounds.
@@ -34,4 +35,20 @@ func parseBuckets(s string) ([]float64, error) {
 	}
 
 	return buckets, nil
+}
+
+// parseCreatedEpoch parses a FreeSWITCH created_epoch string (epoch seconds).
+// Returns an error if the value is not a positive decimal integer.
+func parseCreatedEpoch(s string) (time.Time, error) {
+	v, err := strconv.ParseInt(strings.TrimSpace(s), 10, 64)
+
+	if err != nil {
+		return time.Time{}, fmt.Errorf("invalid created_epoch %q: not a decimal integer", s)
+	}
+
+	if v <= 0 {
+		return time.Time{}, fmt.Errorf("invalid created_epoch %q: must be > 0", s)
+	}
+
+	return time.Unix(v, 0), nil
 }

--- a/channel_duration.go
+++ b/channel_duration.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// parseBuckets parses a comma-separated list of histogram bucket upper bounds.
+// Values must be > 0 and strictly increasing.
+func parseBuckets(s string) ([]float64, error) {
+	parts := strings.Split(s, ",")
+
+	buckets := make([]float64, 0, len(parts))
+
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+
+		value, err := strconv.ParseFloat(trimmed, 64)
+
+		if err != nil {
+			return nil, fmt.Errorf("invalid bucket value %q: not a number", trimmed)
+		}
+
+		if value <= 0 {
+			return nil, fmt.Errorf("invalid bucket value %q: must be > 0", trimmed)
+		}
+
+		if len(buckets) > 0 && value <= buckets[len(buckets)-1] {
+			return nil, fmt.Errorf("invalid bucket value %q: buckets must be strictly increasing", trimmed)
+		}
+
+		buckets = append(buckets, value)
+	}
+
+	return buckets, nil
+}

--- a/channel_duration.go
+++ b/channel_duration.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -92,4 +94,46 @@ func buildChannelDurationHistogram(rows []map[string]any, now time.Time, buckets
 	}
 
 	return histogram, skipped
+}
+
+// channelRowsPayload mirrors the JSON shape of "api show channels as json".
+type channelRowsPayload struct {
+	RowCount int              `json:"row_count"`
+	Rows     []map[string]any `json:"rows"`
+}
+
+// decodeChannelRows decodes the channel rows JSON payload into a slice of maps.
+func decodeChannelRows(payload []byte) ([]map[string]any, error) {
+	var p channelRowsPayload
+
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return nil, fmt.Errorf("cannot decode channel rows JSON: %w", err)
+	}
+
+	return p.Rows, nil
+}
+
+// channelDurationMetrics fetches channels, builds an age histogram, and emits it.
+func (c *Collector) channelDurationMetrics(ch chan<- prometheus.Metric) error {
+	response, err := c.fsCommand("api show channels as json")
+
+	if err != nil {
+		return err
+	}
+
+	rows, err := decodeChannelRows(response)
+
+	if err != nil {
+		return err
+	}
+
+	histogram, skipped := buildChannelDurationHistogram(rows, time.Now(), c.channelDurationBuckets)
+
+	if skipped > 0 {
+		level.Debug(c.logger).Log("msg", "skipped unparseable channel row", "count", skipped)
+	}
+
+	ch <- histogram
+
+	return nil
 }

--- a/collector.go
+++ b/collector.go
@@ -327,6 +327,12 @@ func (c *Collector) scrape(ch chan<- prometheus.Metric) error {
 		}
 	}
 
+	if c.channelDurationEnabled {
+		if err = c.channelDurationMetrics(ch); err != nil {
+			level.Warn(c.logger).Log("msg", "channel duration histogram scrape failed", "err", err)
+		}
+	}
+
 	return nil
 }
 

--- a/collector.go
+++ b/collector.go
@@ -26,11 +26,13 @@ import (
 // Collector implements prometheus.Collector (see below).
 // it also contains the config of the exporter.
 type Collector struct {
-	URI       string
-	Timeout   time.Duration
-	Password  string
-	rtpEnable bool
-	logger    kitlog.Logger
+	URI                    string
+	Timeout                time.Duration
+	Password               string
+	rtpEnable              bool
+	channelDurationEnabled bool
+	channelDurationBuckets []float64
+	logger                 kitlog.Logger
 
 	conn  net.Conn
 	input *bufio.Reader
@@ -214,13 +216,15 @@ var (
 )
 
 // NewCollector processes uri, timeout and methods and returns a new Collector.
-func NewCollector(uri string, timeout time.Duration, password string, rtpEnable bool, logger kitlog.Logger) (*Collector, error) {
+func NewCollector(uri string, timeout time.Duration, password string, rtpEnable bool, channelDurationEnabled bool, channelDurationBuckets []float64, logger kitlog.Logger) (*Collector, error) {
 	var c Collector
 
 	c.URI = uri
 	c.Timeout = timeout
 	c.Password = password
 	c.rtpEnable = rtpEnable
+	c.channelDurationEnabled = channelDurationEnabled
+	c.channelDurationBuckets = channelDurationBuckets
 	if logger == nil {
 		logger = kitlog.NewNopLogger()
 	}

--- a/main.go
+++ b/main.go
@@ -40,6 +40,12 @@ func main() {
 			"[EXPERIMENTAL] Path to config yaml file that can enable TLS or authentication.",
 		).Default("").String()
 		rtpEnable = kingpin.Flag("rtp.enable", "enable rtp info(feature:todo!), default: fasle").Default("false").Bool()
+		channelDurationEnable = kingpin.Flag(
+			"freeswitch.channel-duration.enable",
+			"Enable the freeswitch_channel_duration_seconds histogram of active channel ages.").Default("true").Bool()
+		channelDurationBucketsFlag = kingpin.Flag(
+			"freeswitch.channel-duration.buckets",
+			"Comma-separated histogram bucket upper bounds (seconds) for freeswitch_channel_duration_seconds.").Default("30,60,120,300,600,900,1800,3600,7200,14400,21600,43200,86400,172800").String()
 	)
 	kingpin.Version("freeswitch_exporter\nversion: 1.0.6")
 	kingpin.Parse()
@@ -52,7 +58,13 @@ func main() {
 	}
 	logger := promlog.New(promlogConfig)
 
-	c, err := NewCollector(*scrapeURI, *timeout, *password, *rtpEnable, logger)
+	channelDurationBuckets, err := parseBuckets(*channelDurationBucketsFlag)
+
+	if err != nil {
+		panic(fmt.Sprintf("invalid --freeswitch.channel-duration.buckets: %v", err))
+	}
+
+	c, err := NewCollector(*scrapeURI, *timeout, *password, *rtpEnable, *channelDurationEnable, channelDurationBuckets, logger)
 
 	if err != nil {
 		panic(err)
@@ -78,7 +90,7 @@ func main() {
 			target = fmt.Sprintf("tcp://%s", target)
 		}
 
-		c, colErr := NewCollector(target, *timeout, *password, *rtpEnable, logger)
+		c, colErr := NewCollector(target, *timeout, *password, *rtpEnable, *channelDurationEnable, channelDurationBuckets, logger)
 		if colErr != nil {
 			http.Error(w, fmt.Sprintf("failed to create collector for %s: %s", target, colErr), http.StatusInternalServerError)
 		}

--- a/main.go
+++ b/main.go
@@ -40,9 +40,9 @@ func main() {
 			"[EXPERIMENTAL] Path to config yaml file that can enable TLS or authentication.",
 		).Default("").String()
 		rtpEnable = kingpin.Flag("rtp.enable", "enable rtp info(feature:todo!), default: fasle").Default("false").Bool()
-		channelDurationEnable = kingpin.Flag(
-			"freeswitch.channel-duration.enable",
-			"Enable the freeswitch_channel_duration_seconds histogram of active channel ages.").Default("true").Bool()
+		channelDurationDisable = kingpin.Flag(
+			"freeswitch.channel-duration.disable",
+			"Disable the freeswitch_channel_duration_seconds histogram of active channel ages.").Default("false").Bool()
 		channelDurationBucketsFlag = kingpin.Flag(
 			"freeswitch.channel-duration.buckets",
 			"Comma-separated histogram bucket upper bounds (seconds) for freeswitch_channel_duration_seconds.").Default("30,60,120,300,600,900,1800,3600,7200,14400,21600,43200,86400,172800").String()
@@ -64,7 +64,7 @@ func main() {
 		panic(fmt.Sprintf("invalid --freeswitch.channel-duration.buckets: %v", err))
 	}
 
-	c, err := NewCollector(*scrapeURI, *timeout, *password, *rtpEnable, *channelDurationEnable, channelDurationBuckets, logger)
+	c, err := NewCollector(*scrapeURI, *timeout, *password, *rtpEnable, !*channelDurationDisable, channelDurationBuckets, logger)
 
 	if err != nil {
 		panic(err)
@@ -90,7 +90,7 @@ func main() {
 			target = fmt.Sprintf("tcp://%s", target)
 		}
 
-		c, colErr := NewCollector(target, *timeout, *password, *rtpEnable, *channelDurationEnable, channelDurationBuckets, logger)
+		c, colErr := NewCollector(target, *timeout, *password, *rtpEnable, !*channelDurationDisable, channelDurationBuckets, logger)
 		if colErr != nil {
 			http.Error(w, fmt.Sprintf("failed to create collector for %s: %s", target, colErr), http.StatusInternalServerError)
 		}


### PR DESCRIPTION
Adds a new histogram to track the duration of active FreeSWITCH channels at scrape time. 

* **How it works**: Parses `created_epoch` from the JSON channel list to calculate age in seconds.
* **Flags**: 
  * `--freeswitch.channel-duration.buckets`: Customize bucket upper bounds.
  * `--freeswitch.channel-duration.disable`: Opt-out flag (feature is enabled by default).

### Why this is good
* **Detecting Deadlocks:** Catch zombie channels caused by FreeSWITCH bugs by setting up alerts for channels stuck over a certain threshold (e.g., >6h).
* **Fraud Detection:** Identify toll fraud or abandoned calls that stay connected indefinitely.
* **Traffic Profiling:** Analyze call duration distributions to better understand platform usage and plan for trunk capacity.
* **Routing Issue Detection:** A sudden increase in extremely short calls can act as a canary for systemic call drops or routing misconfigurations.