### PR TITLE
Feat: Add channel duration gauge

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,13 @@ Flags:
       --web.config=""          [EXPERIMENTAL] Path to config yaml file that can
                                enable TLS or authentication.
       --freeswitch.channel-duration.disable
-                               Disable the freeswitch_channel_duration_seconds
-                               histogram of active channel ages. (default: false)
-      --freeswitch.channel-duration.buckets="30,60,120,300,600,900,1800,3600,7200,14400,21600,43200,86400,172800"
-                               Comma-separated histogram bucket upper bounds
-                               (seconds) for freeswitch_channel_duration_seconds.
+                               Disable the
+                               freeswitch_current_channels_by_duration gauge of
+                               active channel counts by age threshold.
+      --freeswitch.channel-duration.thresholds="21600,43200,86400"
+                               Comma-separated, strictly increasing
+                               channel-age thresholds in seconds for
+                               freeswitch_current_channels_by_duration.
       --version                Show application version.
 ```
 
@@ -221,44 +223,45 @@ List of exposed metrics:
 # TYPE freeswitch_memory_uordblks gauge
 # HELP freeswitch_memory_usmblks Max. total allocated space
 # TYPE freeswitch_memory_usmblks gauge
-# HELP freeswitch_channel_duration_seconds Age of currently active FreeSWITCH channels in seconds, observed at scrape time.
-# TYPE freeswitch_channel_duration_seconds histogram
+# HELP freeswitch_current_channels_by_duration Number of currently active FreeSWITCH channels whose age is >= threshold_seconds, observed at scrape time.
+# TYPE freeswitch_current_channels_by_duration gauge
 ```
 
-### Channel duration histogram (zombie channel detection)
+### Current channels by duration (zombie channel detection)
 
-`freeswitch_channel_duration_seconds` is a histogram of **active channel age in seconds, observed at scrape time**. It is fetched via `api show channels as json` and rebuilt fresh on every scrape (it does not accumulate across scrapes). It is enabled by default; disable it with `--freeswitch.channel-duration.disable`, which also skips issuing the underlying command.
+`freeswitch_current_channels_by_duration` is a **gauge family with one series per configured age threshold** (`threshold_seconds` label). Each series' value is the number of currently active channels whose age (`now - created_epoch`) is `>= threshold_seconds`, observed at scrape time — it is fetched via `api show channels as json` and computed fresh on every scrape. Series are independent, not cumulative: a channel older than multiple thresholds is counted in every series it meets (e.g. a 25h-old channel increments the 6h, 12h, and 24h series). It is enabled by default; disable it with `--freeswitch.channel-duration.disable`, which also skips issuing the underlying command.
 
-Default bucket upper bounds (seconds), chosen to include explicit zombie-channel thresholds at 6h/12h/24h:
-
-```
-30, 60, 120, 300, 600, 900, 1800, 3600, 7200, 14400, 21600 (6h), 43200 (12h), 86400 (24h), 172800
-```
-
-Override with `--freeswitch.channel-duration.buckets`, a comma-separated, strictly increasing list of positive values (e.g. `--freeswitch.channel-duration.buckets=30,60,300`). An invalid list (non-numeric, `<= 0`, or not strictly increasing) causes the exporter to fail at startup with an error naming the offending value.
-
-Example output:
+Default thresholds (seconds) — 6h/12h/24h:
 
 ```
-# HELP freeswitch_channel_duration_seconds Age of currently active FreeSWITCH channels in seconds, observed at scrape time.
-# TYPE freeswitch_channel_duration_seconds histogram
-freeswitch_channel_duration_seconds_bucket{le="30"} 0
-freeswitch_channel_duration_seconds_bucket{le="60"} 0
-freeswitch_channel_duration_seconds_bucket{le="21600"} 3
-freeswitch_channel_duration_seconds_bucket{le="43200"} 4
-freeswitch_channel_duration_seconds_bucket{le="86400"} 5
-freeswitch_channel_duration_seconds_bucket{le="+Inf"} 5
-freeswitch_channel_duration_seconds_sum 432000
-freeswitch_channel_duration_seconds_count 5
+21600 (6h), 43200 (12h), 86400 (24h)
 ```
 
-Number of channels older than 6h/12h/24h can be computed with PromQL:
+Override with `--freeswitch.channel-duration.thresholds`, a comma-separated, strictly increasing list of positive values (e.g. `--freeswitch.channel-duration.thresholds=21600,43200,86400`). An invalid list (non-numeric, `<= 0`, or not strictly increasing) causes the exporter to fail at startup with an error naming the offending value.
+
+Example output (3 channels older than every configured threshold):
 
 ```
-freeswitch_channel_duration_seconds_count - freeswitch_channel_duration_seconds_bucket{le="21600"}  # older than 6h
-freeswitch_channel_duration_seconds_count - freeswitch_channel_duration_seconds_bucket{le="43200"}  # older than 12h
-freeswitch_channel_duration_seconds_count - freeswitch_channel_duration_seconds_bucket{le="86400"}  # older than 24h
+# HELP freeswitch_current_channels_by_duration Number of currently active FreeSWITCH channels whose age is >= threshold_seconds, observed at scrape time.
+# TYPE freeswitch_current_channels_by_duration gauge
+freeswitch_current_channels_by_duration{threshold_seconds="10"} 3
+freeswitch_current_channels_by_duration{threshold_seconds="30"} 3
+freeswitch_current_channels_by_duration{threshold_seconds="60"} 3
 ```
+
+Alert on zombie channels directly, no subtraction needed. Prometheus:
+
+```
+freeswitch_current_channels_by_duration{threshold_seconds="21600"} > 0  # 1+ channel older than 6h
+```
+
+Datadog monitor query:
+
+```
+avg(last_5m):avg:freeswitch.current_channels_by_duration{threshold_seconds:21600} > 0
+```
+
+**Datadog Autodiscovery note:** if your Agent's OpenMetrics/Autodiscovery metric filter matches `freeswitch_channel_.*`, it will **not** match `freeswitch_current_channels_by_duration`. Update the filter to `freeswitch_current_channels_.*` (or add the exact metric name) so this gauge is picked up.
 
 ## Compiling
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ List of exposed metrics:
 # TYPE freeswitch_current_calls gauge
 # HELP freeswitch_current_channels Number of channels active
 # TYPE freeswitch_current_channels gauge
+# HELP freeswitch_current_channels_by_duration Number of currently active FreeSWITCH channels whose age is >= threshold_seconds, observed at scrape time.
+# TYPE freeswitch_current_channels_by_duration gauge
 # HELP freeswitch_current_idle_cpu CPU idle
 # TYPE freeswitch_current_idle_cpu gauge
 # HELP freeswitch_current_sessions Number of sessions active
@@ -223,8 +225,6 @@ List of exposed metrics:
 # TYPE freeswitch_memory_uordblks gauge
 # HELP freeswitch_memory_usmblks Max. total allocated space
 # TYPE freeswitch_memory_usmblks gauge
-# HELP freeswitch_current_channels_by_duration Number of currently active FreeSWITCH channels whose age is >= threshold_seconds, observed at scrape time.
-# TYPE freeswitch_current_channels_by_duration gauge
 ```
 
 ## Compiling

--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ Flags:
                                Password for freeswitch event socket.
       --web.config=""          [EXPERIMENTAL] Path to config yaml file that can
                                enable TLS or authentication.
+      --freeswitch.channel-duration.enable
+                               Enable the freeswitch_channel_duration_seconds
+                               histogram of active channel ages. (default: true)
+      --freeswitch.channel-duration.buckets="30,60,120,300,600,900,1800,3600,7200,14400,21600,43200,86400,172800"
+                               Comma-separated histogram bucket upper bounds
+                               (seconds) for freeswitch_channel_duration_seconds.
       --version                Show application version.
 ```
 
@@ -215,6 +221,43 @@ List of exposed metrics:
 # TYPE freeswitch_memory_uordblks gauge
 # HELP freeswitch_memory_usmblks Max. total allocated space
 # TYPE freeswitch_memory_usmblks gauge
+# HELP freeswitch_channel_duration_seconds Age of currently active FreeSWITCH channels in seconds, observed at scrape time.
+# TYPE freeswitch_channel_duration_seconds histogram
+```
+
+### Channel duration histogram (zombie channel detection)
+
+`freeswitch_channel_duration_seconds` is a histogram of **active channel age in seconds, observed at scrape time**. It is fetched via `api show channels as json` and rebuilt fresh on every scrape (it does not accumulate across scrapes). It is enabled by default; disable it with `--freeswitch.channel-duration.enable=false`, which also skips issuing the underlying command.
+
+Default bucket upper bounds (seconds), chosen to include explicit zombie-channel thresholds at 6h/12h/24h:
+
+```
+30, 60, 120, 300, 600, 900, 1800, 3600, 7200, 14400, 21600 (6h), 43200 (12h), 86400 (24h), 172800
+```
+
+Override with `--freeswitch.channel-duration.buckets`, a comma-separated, strictly increasing list of positive values (e.g. `--freeswitch.channel-duration.buckets=30,60,300`). An invalid list (non-numeric, `<= 0`, or not strictly increasing) causes the exporter to fail at startup with an error naming the offending value.
+
+Example output:
+
+```
+# HELP freeswitch_channel_duration_seconds Age of currently active FreeSWITCH channels in seconds, observed at scrape time.
+# TYPE freeswitch_channel_duration_seconds histogram
+freeswitch_channel_duration_seconds_bucket{le="30"} 0
+freeswitch_channel_duration_seconds_bucket{le="60"} 0
+freeswitch_channel_duration_seconds_bucket{le="21600"} 3
+freeswitch_channel_duration_seconds_bucket{le="43200"} 4
+freeswitch_channel_duration_seconds_bucket{le="86400"} 5
+freeswitch_channel_duration_seconds_bucket{le="+Inf"} 5
+freeswitch_channel_duration_seconds_sum 432000
+freeswitch_channel_duration_seconds_count 5
+```
+
+Number of channels older than 6h/12h/24h can be computed with PromQL:
+
+```
+freeswitch_channel_duration_seconds_count - freeswitch_channel_duration_seconds_bucket{le="21600"}  # older than 6h
+freeswitch_channel_duration_seconds_count - freeswitch_channel_duration_seconds_bucket{le="43200"}  # older than 12h
+freeswitch_channel_duration_seconds_count - freeswitch_channel_duration_seconds_bucket{le="86400"}  # older than 24h
 ```
 
 ## Compiling

--- a/README.md
+++ b/README.md
@@ -236,9 +236,8 @@ List of exposed metrics:
 * **Detecting Deadlocks:** Catch zombie channels caused by FreeSWITCH bugs by setting up alerts for channels stuck over a certain threshold (e.g., >6h).
 * **Fraud Detection:** Identify toll fraud or abandoned calls that stay connected indefinitely.
 * **Traffic Profiling:** Analyze call duration distributions to better understand platform usage and plan for trunk capacity.
-* **Routing Issue Detection:** A sudden increase in extremely short calls can act as a canary for systemic call drops or routing misconfigurations.
 
-Default thresholds (seconds), spanning from short-lived calls to zombie-channel ranges — suited for the general profiling/routing/fraud use cases above:
+Default thresholds (seconds), spanning a broad range of ages — suited for the general profiling/fraud use cases above:
 
 ```
 30 (30s), 60 (1m), 120 (2m), 300 (5m), 600 (10m), 900 (15m), 1800 (30m), 3600 (1h), 7200 (2h), 14400 (4h), 21600 (6h), 43200 (12h), 86400 (24h), 172800 (48h)
@@ -263,16 +262,6 @@ Alert on zombie channels directly, no subtraction needed:
 ```
 freeswitch_current_channels_by_duration{threshold_seconds="21600"} > 0  # 1+ channel older than 6h
 ```
-
-#### Estimating short-lived calls (routing issue detection)
-
-`freeswitch_current_channels_by_duration{threshold_seconds="T"}` only counts channels *older than or equal to* `T`. To estimate channels *younger than* the smallest configured threshold (i.e. very short-lived/just-started calls — a canary for dropped calls or routing misconfigurations), subtract it from the total active channel count (`freeswitch_current_channels`):
-
-```
-freeswitch_current_channels - freeswitch_current_channels_by_duration{threshold_seconds="30"}  # channels younger than 30s
-```
-
-With the default thresholds, `30` is the smallest configured value. A sudden, sustained rise in this value compared to normal traffic levels suggests calls are being dropped or misrouted shortly after being established.
 
 If your monitoring filter/allowlist only matches names like `freeswitch_channel_.*`, note it will **not** match `freeswitch_current_channels_by_duration` — update the filter to `freeswitch_current_channels_.*` (or add the exact metric name) so this gauge is picked up.
 

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ List of exposed metrics:
 
 ### Channel duration histogram (zombie channel detection)
 
-`freeswitch_channel_duration_seconds` is a histogram of **active channel age in seconds, observed at scrape time**. It is fetched via `api show channels as json` and rebuilt fresh on every scrape (it does not accumulate across scrapes). It is enabled by default; disable it with `--freeswitch.channel-duration.enable=false`, which also skips issuing the underlying command.
+`freeswitch_channel_duration_seconds` is a histogram of **active channel age in seconds, observed at scrape time**. It is fetched via `api show channels as json` and rebuilt fresh on every scrape (it does not accumulate across scrapes). It is enabled by default; disable it with `--no-freeswitch.channel-duration.enable`, which also skips issuing the underlying command.
 
 Default bucket upper bounds (seconds), chosen to include explicit zombie-channel thresholds at 6h/12h/24h:
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Flags:
                                Disable the
                                freeswitch_current_channels_by_duration gauge of
                                active channel counts by age threshold.
-      --freeswitch.channel-duration.thresholds="21600,43200,86400"
+      --freeswitch.channel-duration.thresholds="30,60,120,300,600,900,1800,3600,7200,14400,21600,43200,86400,172800"
                                Comma-separated, strictly increasing
                                channel-age thresholds in seconds for
                                freeswitch_current_channels_by_duration.
@@ -227,17 +227,26 @@ List of exposed metrics:
 # TYPE freeswitch_current_channels_by_duration gauge
 ```
 
-### Current channels by duration (zombie channel detection)
+### Current channels by duration
 
 `freeswitch_current_channels_by_duration` is a **gauge family with one series per configured age threshold** (`threshold_seconds` label). Each series' value is the number of currently active channels whose age (`now - created_epoch`) is `>= threshold_seconds`, observed at scrape time — it is fetched via `api show channels as json` and computed fresh on every scrape. Series are independent, not cumulative: a channel older than multiple thresholds is counted in every series it meets (e.g. a 25h-old channel increments the 6h, 12h, and 24h series). It is enabled by default; disable it with `--freeswitch.channel-duration.disable`, which also skips issuing the underlying command.
 
-Default thresholds (seconds) — 6h/12h/24h:
+#### Use cases
+
+* **Detecting Deadlocks:** Catch zombie channels caused by FreeSWITCH bugs by setting up alerts for channels stuck over a certain threshold (e.g., >6h).
+* **Fraud Detection:** Identify toll fraud or abandoned calls that stay connected indefinitely.
+* **Traffic Profiling:** Analyze call duration distributions to better understand platform usage and plan for trunk capacity.
+* **Routing Issue Detection:** A sudden increase in extremely short calls can act as a canary for systemic call drops or routing misconfigurations.
+
+Default thresholds (seconds), spanning from short-lived calls to zombie-channel ranges — suited for the general profiling/routing/fraud use cases above:
 
 ```
-21600 (6h), 43200 (12h), 86400 (24h)
+30 (30s), 60 (1m), 120 (2m), 300 (5m), 600 (10m), 900 (15m), 1800 (30m), 3600 (1h), 7200 (2h), 14400 (4h), 21600 (6h), 43200 (12h), 86400 (24h), 172800 (48h)
 ```
 
-Override with `--freeswitch.channel-duration.thresholds`, a comma-separated, strictly increasing list of positive values (e.g. `--freeswitch.channel-duration.thresholds=21600,43200,86400`). An invalid list (non-numeric, `<= 0`, or not strictly increasing) causes the exporter to fail at startup with an error naming the offending value.
+If you only care about zombie-channel detection (deadlocks/fraud) and not the shorter-lived traffic-profiling thresholds, override with just the 6h/12h/24h set: `--freeswitch.channel-duration.thresholds=21600,43200,86400` (`21600 (6h), 43200 (12h), 86400 (24h)`).
+
+Override with `--freeswitch.channel-duration.thresholds`, a comma-separated, strictly increasing list of positive values. An invalid list (non-numeric, `<= 0`, or not strictly increasing) causes the exporter to fail at startup with an error naming the offending value.
 
 Example output (3 channels older than every configured threshold):
 

--- a/README.md
+++ b/README.md
@@ -258,19 +258,23 @@ freeswitch_current_channels_by_duration{threshold_seconds="30"} 3
 freeswitch_current_channels_by_duration{threshold_seconds="60"} 3
 ```
 
-Alert on zombie channels directly, no subtraction needed. Prometheus:
+Alert on zombie channels directly, no subtraction needed:
 
 ```
 freeswitch_current_channels_by_duration{threshold_seconds="21600"} > 0  # 1+ channel older than 6h
 ```
 
-Datadog monitor query:
+#### Estimating short-lived calls (routing issue detection)
+
+`freeswitch_current_channels_by_duration{threshold_seconds="T"}` only counts channels *older than or equal to* `T`. To estimate channels *younger than* the smallest configured threshold (i.e. very short-lived/just-started calls — a canary for dropped calls or routing misconfigurations), subtract it from the total active channel count (`freeswitch_current_channels`):
 
 ```
-avg(last_5m):avg:freeswitch.current_channels_by_duration{threshold_seconds:21600} > 0
+freeswitch_current_channels - freeswitch_current_channels_by_duration{threshold_seconds="30"}  # channels younger than 30s
 ```
 
-**Datadog Autodiscovery note:** if your Agent's OpenMetrics/Autodiscovery metric filter matches `freeswitch_channel_.*`, it will **not** match `freeswitch_current_channels_by_duration`. Update the filter to `freeswitch_current_channels_.*` (or add the exact metric name) so this gauge is picked up.
+With the default thresholds, `30` is the smallest configured value. A sudden, sustained rise in this value compared to normal traffic levels suggests calls are being dropped or misrouted shortly after being established.
+
+If your monitoring filter/allowlist only matches names like `freeswitch_channel_.*`, note it will **not** match `freeswitch_current_channels_by_duration` — update the filter to `freeswitch_current_channels_.*` (or add the exact metric name) so this gauge is picked up.
 
 ## Compiling
 

--- a/README.md
+++ b/README.md
@@ -227,44 +227,6 @@ List of exposed metrics:
 # TYPE freeswitch_current_channels_by_duration gauge
 ```
 
-### Current channels by duration
-
-`freeswitch_current_channels_by_duration` is a **gauge family with one series per configured age threshold** (`threshold_seconds` label). Each series' value is the number of currently active channels whose age (`now - created_epoch`) is `>= threshold_seconds`, observed at scrape time — it is fetched via `api show channels as json` and computed fresh on every scrape. Series are independent, not cumulative: a channel older than multiple thresholds is counted in every series it meets (e.g. a 25h-old channel increments the 6h, 12h, and 24h series). It is enabled by default; disable it with `--freeswitch.channel-duration.disable`, which also skips issuing the underlying command.
-
-#### Use cases
-
-* **Detecting Deadlocks:** Catch zombie channels caused by FreeSWITCH bugs by setting up alerts for channels stuck over a certain threshold (e.g., >6h).
-* **Fraud Detection:** Identify toll fraud or abandoned calls that stay connected indefinitely.
-* **Traffic Profiling:** Analyze call duration distributions to better understand platform usage and plan for trunk capacity.
-
-Default thresholds (seconds), spanning a broad range of ages — suited for the general profiling/fraud use cases above:
-
-```
-30 (30s), 60 (1m), 120 (2m), 300 (5m), 600 (10m), 900 (15m), 1800 (30m), 3600 (1h), 7200 (2h), 14400 (4h), 21600 (6h), 43200 (12h), 86400 (24h), 172800 (48h)
-```
-
-If you only care about zombie-channel detection (deadlocks/fraud) and not the shorter-lived traffic-profiling thresholds, override with just the 6h/12h/24h set: `--freeswitch.channel-duration.thresholds=21600,43200,86400` (`21600 (6h), 43200 (12h), 86400 (24h)`).
-
-Override with `--freeswitch.channel-duration.thresholds`, a comma-separated, strictly increasing list of positive values. An invalid list (non-numeric, `<= 0`, or not strictly increasing) causes the exporter to fail at startup with an error naming the offending value.
-
-Example output (3 channels older than every configured threshold):
-
-```
-# HELP freeswitch_current_channels_by_duration Number of currently active FreeSWITCH channels whose age is >= threshold_seconds, observed at scrape time.
-# TYPE freeswitch_current_channels_by_duration gauge
-freeswitch_current_channels_by_duration{threshold_seconds="10"} 3
-freeswitch_current_channels_by_duration{threshold_seconds="30"} 3
-freeswitch_current_channels_by_duration{threshold_seconds="60"} 3
-```
-
-Alert on zombie channels directly, no subtraction needed:
-
-```
-freeswitch_current_channels_by_duration{threshold_seconds="21600"} > 0  # 1+ channel older than 6h
-```
-
-If your monitoring filter/allowlist only matches names like `freeswitch_channel_.*`, note it will **not** match `freeswitch_current_channels_by_duration` — update the filter to `freeswitch_current_channels_.*` (or add the exact metric name) so this gauge is picked up.
-
 ## Compiling
 
 With go 1.20+, clone the project and:

--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ Flags:
                                Password for freeswitch event socket.
       --web.config=""          [EXPERIMENTAL] Path to config yaml file that can
                                enable TLS or authentication.
-      --freeswitch.channel-duration.enable
-                               Enable the freeswitch_channel_duration_seconds
-                               histogram of active channel ages. (default: true)
+      --freeswitch.channel-duration.disable
+                               Disable the freeswitch_channel_duration_seconds
+                               histogram of active channel ages. (default: false)
       --freeswitch.channel-duration.buckets="30,60,120,300,600,900,1800,3600,7200,14400,21600,43200,86400,172800"
                                Comma-separated histogram bucket upper bounds
                                (seconds) for freeswitch_channel_duration_seconds.
@@ -227,7 +227,7 @@ List of exposed metrics:
 
 ### Channel duration histogram (zombie channel detection)
 
-`freeswitch_channel_duration_seconds` is a histogram of **active channel age in seconds, observed at scrape time**. It is fetched via `api show channels as json` and rebuilt fresh on every scrape (it does not accumulate across scrapes). It is enabled by default; disable it with `--no-freeswitch.channel-duration.enable`, which also skips issuing the underlying command.
+`freeswitch_channel_duration_seconds` is a histogram of **active channel age in seconds, observed at scrape time**. It is fetched via `api show channels as json` and rebuilt fresh on every scrape (it does not accumulate across scrapes). It is enabled by default; disable it with `--freeswitch.channel-duration.disable`, which also skips issuing the underlying command.
 
 Default bucket upper bounds (seconds), chosen to include explicit zombie-channel thresholds at 6h/12h/24h:
 

--- a/channel_duration.go
+++ b/channel_duration.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // parseBuckets parses a comma-separated list of histogram bucket upper bounds.
@@ -51,4 +53,43 @@ func parseCreatedEpoch(s string) (time.Time, error) {
 	}
 
 	return time.Unix(v, 0), nil
+}
+
+// buildChannelDurationHistogram builds a histogram of active channel ages (in seconds).
+// Skips rows with invalid created_epoch and clamps negative ages to 0.
+func buildChannelDurationHistogram(rows []map[string]any, now time.Time, buckets []float64) (prometheus.Histogram, int) {
+	histogram := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: namespace,
+		Name:      "channel_duration_seconds",
+		Help:      "Age of currently active FreeSWITCH channels in seconds, observed at scrape time.",
+		Buckets:   buckets,
+	})
+
+	skipped := 0
+
+	for _, row := range rows {
+		raw, ok := row["created_epoch"].(string)
+
+		if !ok {
+			skipped++
+			continue
+		}
+
+		start, err := parseCreatedEpoch(raw)
+
+		if err != nil {
+			skipped++
+			continue
+		}
+
+		age := now.Sub(start).Seconds()
+
+		if age < 0 {
+			age = 0
+		}
+
+		histogram.Observe(age)
+	}
+
+	return histogram, skipped
 }

--- a/channel_duration.go
+++ b/channel_duration.go
@@ -11,12 +11,12 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-// parseBuckets parses a comma-separated list of histogram bucket upper bounds.
+// parseThresholds parses a comma-separated list of channel-age thresholds (seconds).
 // Values must be > 0 and strictly increasing.
-func parseBuckets(s string) ([]float64, error) {
+func parseThresholds(s string) ([]float64, error) {
 	parts := strings.Split(s, ",")
 
-	buckets := make([]float64, 0, len(parts))
+	thresholds := make([]float64, 0, len(parts))
 
 	for _, part := range parts {
 		trimmed := strings.TrimSpace(part)
@@ -24,21 +24,21 @@ func parseBuckets(s string) ([]float64, error) {
 		value, err := strconv.ParseFloat(trimmed, 64)
 
 		if err != nil {
-			return nil, fmt.Errorf("invalid bucket value %q: not a number", trimmed)
+			return nil, fmt.Errorf("invalid threshold value %q: not a number", trimmed)
 		}
 
 		if value <= 0 {
-			return nil, fmt.Errorf("invalid bucket value %q: must be > 0", trimmed)
+			return nil, fmt.Errorf("invalid threshold value %q: must be > 0", trimmed)
 		}
 
-		if len(buckets) > 0 && value <= buckets[len(buckets)-1] {
-			return nil, fmt.Errorf("invalid bucket value %q: buckets must be strictly increasing", trimmed)
+		if len(thresholds) > 0 && value <= thresholds[len(thresholds)-1] {
+			return nil, fmt.Errorf("invalid threshold value %q: thresholds must be strictly increasing", trimmed)
 		}
 
-		buckets = append(buckets, value)
+		thresholds = append(thresholds, value)
 	}
 
-	return buckets, nil
+	return thresholds, nil
 }
 
 // parseCreatedEpoch parses a FreeSWITCH created_epoch string (epoch seconds).
@@ -135,13 +135,13 @@ func (c *Collector) channelDurationMetrics(ch chan<- prometheus.Metric) error {
 		return err
 	}
 
-	counts, skipped := countChannelsByDuration(rows, time.Now(), c.channelDurationBuckets)
+	counts, skipped := countChannelsByDuration(rows, time.Now(), c.channelDurationThresholds)
 
 	if skipped > 0 {
 		level.Debug(c.logger).Log("msg", "skipped unparseable channel row", "count", skipped)
 	}
 
-	for i, threshold := range c.channelDurationBuckets {
+	for i, threshold := range c.channelDurationThresholds {
 		metric, err := prometheus.NewConstMetric(
 			channelDurationDesc,
 			prometheus.GaugeValue,

--- a/channel_duration.go
+++ b/channel_duration.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // parseBuckets parses a comma-separated list of histogram bucket upper bounds.
@@ -34,4 +35,20 @@ func parseBuckets(s string) ([]float64, error) {
 	}
 
 	return buckets, nil
+}
+
+// parseCreatedEpoch parses a FreeSWITCH created_epoch string (epoch seconds).
+// Returns an error if the value is not a positive decimal integer.
+func parseCreatedEpoch(s string) (time.Time, error) {
+	v, err := strconv.ParseInt(strings.TrimSpace(s), 10, 64)
+
+	if err != nil {
+		return time.Time{}, fmt.Errorf("invalid created_epoch %q: not a decimal integer", s)
+	}
+
+	if v <= 0 {
+		return time.Time{}, fmt.Errorf("invalid created_epoch %q: must be > 0", s)
+	}
+
+	return time.Unix(v, 0), nil
 }

--- a/channel_duration.go
+++ b/channel_duration.go
@@ -96,6 +96,45 @@ func buildChannelDurationHistogram(rows []map[string]any, now time.Time, buckets
 	return histogram, skipped
 }
 
+// countChannelsByDuration counts, for each threshold, the number of active channels
+// whose age (now - created_epoch) is >= that threshold. Counts are independent per
+// threshold (a channel older than multiple thresholds increments each). Skips rows
+// with missing/invalid created_epoch and clamps negative ages to 0.
+func countChannelsByDuration(rows []map[string]any, now time.Time, thresholds []float64) ([]float64, int) {
+	counts := make([]float64, len(thresholds))
+	skipped := 0
+
+	for _, row := range rows {
+		raw, ok := row["created_epoch"].(string)
+
+		if !ok {
+			skipped++
+			continue
+		}
+
+		start, err := parseCreatedEpoch(raw)
+
+		if err != nil {
+			skipped++
+			continue
+		}
+
+		age := now.Sub(start).Seconds()
+
+		if age < 0 {
+			age = 0
+		}
+
+		for i, threshold := range thresholds {
+			if age >= threshold {
+				counts[i]++
+			}
+		}
+	}
+
+	return counts, skipped
+}
+
 // channelRowsPayload mirrors the JSON shape of "api show channels as json".
 type channelRowsPayload struct {
 	RowCount int              `json:"row_count"`

--- a/channel_duration.go
+++ b/channel_duration.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// parseBuckets parses a comma-separated list of histogram bucket upper bounds.
+// Values must be > 0 and strictly increasing.
+func parseBuckets(s string) ([]float64, error) {
+	parts := strings.Split(s, ",")
+
+	buckets := make([]float64, 0, len(parts))
+
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+
+		value, err := strconv.ParseFloat(trimmed, 64)
+
+		if err != nil {
+			return nil, fmt.Errorf("invalid bucket value %q: not a number", trimmed)
+		}
+
+		if value <= 0 {
+			return nil, fmt.Errorf("invalid bucket value %q: must be > 0", trimmed)
+		}
+
+		if len(buckets) > 0 && value <= buckets[len(buckets)-1] {
+			return nil, fmt.Errorf("invalid bucket value %q: buckets must be strictly increasing", trimmed)
+		}
+
+		buckets = append(buckets, value)
+	}
+
+	return buckets, nil
+}

--- a/channel_duration.go
+++ b/channel_duration.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -92,4 +94,46 @@ func buildChannelDurationHistogram(rows []map[string]any, now time.Time, buckets
 	}
 
 	return histogram, skipped
+}
+
+// channelRowsPayload mirrors the JSON shape of "api show channels as json".
+type channelRowsPayload struct {
+	RowCount int              `json:"row_count"`
+	Rows     []map[string]any `json:"rows"`
+}
+
+// decodeChannelRows decodes the channel rows JSON payload into a slice of maps.
+func decodeChannelRows(payload []byte) ([]map[string]any, error) {
+	var p channelRowsPayload
+
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return nil, fmt.Errorf("cannot decode channel rows JSON: %w", err)
+	}
+
+	return p.Rows, nil
+}
+
+// channelDurationMetrics fetches channels, builds an age histogram, and emits it.
+func (c *Collector) channelDurationMetrics(ch chan<- prometheus.Metric) error {
+	response, err := c.fsCommand("api show channels as json")
+
+	if err != nil {
+		return err
+	}
+
+	rows, err := decodeChannelRows(response)
+
+	if err != nil {
+		return err
+	}
+
+	histogram, skipped := buildChannelDurationHistogram(rows, time.Now(), c.channelDurationBuckets)
+
+	if skipped > 0 {
+		level.Debug(c.logger).Log("msg", "skipped unparseable channel row", "count", skipped)
+	}
+
+	ch <- histogram
+
+	return nil
 }

--- a/channel_duration.go
+++ b/channel_duration.go
@@ -57,45 +57,6 @@ func parseCreatedEpoch(s string) (time.Time, error) {
 	return time.Unix(v, 0), nil
 }
 
-// buildChannelDurationHistogram builds a histogram of active channel ages (in seconds).
-// Skips rows with invalid created_epoch and clamps negative ages to 0.
-func buildChannelDurationHistogram(rows []map[string]any, now time.Time, buckets []float64) (prometheus.Histogram, int) {
-	histogram := prometheus.NewHistogram(prometheus.HistogramOpts{
-		Namespace: namespace,
-		Name:      "channel_duration_seconds",
-		Help:      "Age of currently active FreeSWITCH channels in seconds, observed at scrape time.",
-		Buckets:   buckets,
-	})
-
-	skipped := 0
-
-	for _, row := range rows {
-		raw, ok := row["created_epoch"].(string)
-
-		if !ok {
-			skipped++
-			continue
-		}
-
-		start, err := parseCreatedEpoch(raw)
-
-		if err != nil {
-			skipped++
-			continue
-		}
-
-		age := now.Sub(start).Seconds()
-
-		if age < 0 {
-			age = 0
-		}
-
-		histogram.Observe(age)
-	}
-
-	return histogram, skipped
-}
-
 // countChannelsByDuration counts, for each threshold, the number of active channels
 // whose age (now - created_epoch) is >= that threshold. Counts are independent per
 // threshold (a channel older than multiple thresholds increments each). Skips rows
@@ -152,7 +113,15 @@ func decodeChannelRows(payload []byte) ([]map[string]any, error) {
 	return p.Rows, nil
 }
 
-// channelDurationMetrics fetches channels, builds an age histogram, and emits it.
+var channelDurationDesc = prometheus.NewDesc(
+	namespace+"_current_channels_by_duration",
+	"Number of currently active FreeSWITCH channels whose age is >= threshold_seconds, observed at scrape time.",
+	[]string{"threshold_seconds"},
+	nil,
+)
+
+// channelDurationMetrics fetches channels, counts them per age threshold, and emits
+// one gauge sample per threshold.
 func (c *Collector) channelDurationMetrics(ch chan<- prometheus.Metric) error {
 	response, err := c.fsCommand("api show channels as json")
 
@@ -166,13 +135,26 @@ func (c *Collector) channelDurationMetrics(ch chan<- prometheus.Metric) error {
 		return err
 	}
 
-	histogram, skipped := buildChannelDurationHistogram(rows, time.Now(), c.channelDurationBuckets)
+	counts, skipped := countChannelsByDuration(rows, time.Now(), c.channelDurationBuckets)
 
 	if skipped > 0 {
 		level.Debug(c.logger).Log("msg", "skipped unparseable channel row", "count", skipped)
 	}
 
-	ch <- histogram
+	for i, threshold := range c.channelDurationBuckets {
+		metric, err := prometheus.NewConstMetric(
+			channelDurationDesc,
+			prometheus.GaugeValue,
+			counts[i],
+			strconv.FormatInt(int64(threshold), 10),
+		)
+
+		if err != nil {
+			return err
+		}
+
+		ch <- metric
+	}
 
 	return nil
 }

--- a/collector.go
+++ b/collector.go
@@ -327,6 +327,12 @@ func (c *Collector) scrape(ch chan<- prometheus.Metric) error {
 		}
 	}
 
+	if c.channelDurationEnabled {
+		if err = c.channelDurationMetrics(ch); err != nil {
+			level.Warn(c.logger).Log("msg", "channel duration histogram scrape failed", "err", err)
+		}
+	}
+
 	return nil
 }
 

--- a/collector.go
+++ b/collector.go
@@ -329,7 +329,7 @@ func (c *Collector) scrape(ch chan<- prometheus.Metric) error {
 
 	if c.channelDurationEnabled {
 		if err = c.channelDurationMetrics(ch); err != nil {
-			level.Warn(c.logger).Log("msg", "channel duration histogram scrape failed", "err", err)
+			return err
 		}
 	}
 

--- a/collector.go
+++ b/collector.go
@@ -26,13 +26,13 @@ import (
 // Collector implements prometheus.Collector (see below).
 // it also contains the config of the exporter.
 type Collector struct {
-	URI                    string
-	Timeout                time.Duration
-	Password               string
-	rtpEnable              bool
-	channelDurationEnabled bool
-	channelDurationBuckets []float64
-	logger                 kitlog.Logger
+	URI                       string
+	Timeout                   time.Duration
+	Password                  string
+	rtpEnable                 bool
+	channelDurationEnabled    bool
+	channelDurationThresholds []float64
+	logger                    kitlog.Logger
 
 	conn  net.Conn
 	input *bufio.Reader
@@ -216,7 +216,7 @@ var (
 )
 
 // NewCollector processes uri, timeout and methods and returns a new Collector.
-func NewCollector(uri string, timeout time.Duration, password string, rtpEnable bool, channelDurationEnabled bool, channelDurationBuckets []float64, logger kitlog.Logger) (*Collector, error) {
+func NewCollector(uri string, timeout time.Duration, password string, rtpEnable bool, channelDurationEnabled bool, channelDurationThresholds []float64, logger kitlog.Logger) (*Collector, error) {
 	var c Collector
 
 	c.URI = uri
@@ -224,7 +224,7 @@ func NewCollector(uri string, timeout time.Duration, password string, rtpEnable 
 	c.Password = password
 	c.rtpEnable = rtpEnable
 	c.channelDurationEnabled = channelDurationEnabled
-	c.channelDurationBuckets = channelDurationBuckets
+	c.channelDurationThresholds = channelDurationThresholds
 	if logger == nil {
 		logger = kitlog.NewNopLogger()
 	}

--- a/collector.go
+++ b/collector.go
@@ -26,11 +26,13 @@ import (
 // Collector implements prometheus.Collector (see below).
 // it also contains the config of the exporter.
 type Collector struct {
-	URI       string
-	Timeout   time.Duration
-	Password  string
-	rtpEnable bool
-	logger    kitlog.Logger
+	URI                    string
+	Timeout                time.Duration
+	Password               string
+	rtpEnable              bool
+	channelDurationEnabled bool
+	channelDurationBuckets []float64
+	logger                 kitlog.Logger
 
 	conn  net.Conn
 	input *bufio.Reader
@@ -214,13 +216,15 @@ var (
 )
 
 // NewCollector processes uri, timeout and methods and returns a new Collector.
-func NewCollector(uri string, timeout time.Duration, password string, rtpEnable bool, logger kitlog.Logger) (*Collector, error) {
+func NewCollector(uri string, timeout time.Duration, password string, rtpEnable bool, channelDurationEnabled bool, channelDurationBuckets []float64, logger kitlog.Logger) (*Collector, error) {
 	var c Collector
 
 	c.URI = uri
 	c.Timeout = timeout
 	c.Password = password
 	c.rtpEnable = rtpEnable
+	c.channelDurationEnabled = channelDurationEnabled
+	c.channelDurationBuckets = channelDurationBuckets
 	if logger == nil {
 		logger = kitlog.NewNopLogger()
 	}

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ func main() {
 			"web.config",
 			"[EXPERIMENTAL] Path to config yaml file that can enable TLS or authentication.",
 		).Default("").String()
-		rtpEnable = kingpin.Flag("rtp.enable", "enable rtp info(feature:todo!), default: fasle").Default("false").Bool()
+		rtpEnable              = kingpin.Flag("rtp.enable", "enable rtp info(feature:todo!), default: fasle").Default("false").Bool()
 		channelDurationDisable = kingpin.Flag(
 			"freeswitch.channel-duration.disable",
 			"Disable the freeswitch_channel_duration_seconds histogram of active channel ages.").Default("false").Bool()
@@ -58,13 +58,13 @@ func main() {
 	}
 	logger := promlog.New(promlogConfig)
 
-	channelDurationBuckets, err := parseBuckets(*channelDurationBucketsFlag)
+	channelDurationThresholds, err := parseThresholds(*channelDurationBucketsFlag)
 
 	if err != nil {
 		panic(fmt.Sprintf("invalid --freeswitch.channel-duration.buckets: %v", err))
 	}
 
-	c, err := NewCollector(*scrapeURI, *timeout, *password, *rtpEnable, !*channelDurationDisable, channelDurationBuckets, logger)
+	c, err := NewCollector(*scrapeURI, *timeout, *password, *rtpEnable, !*channelDurationDisable, channelDurationThresholds, logger)
 
 	if err != nil {
 		panic(err)
@@ -90,7 +90,7 @@ func main() {
 			target = fmt.Sprintf("tcp://%s", target)
 		}
 
-		c, colErr := NewCollector(target, *timeout, *password, *rtpEnable, !*channelDurationDisable, channelDurationBuckets, logger)
+		c, colErr := NewCollector(target, *timeout, *password, *rtpEnable, !*channelDurationDisable, channelDurationThresholds, logger)
 		if colErr != nil {
 			http.Error(w, fmt.Sprintf("failed to create collector for %s: %s", target, colErr), http.StatusInternalServerError)
 		}

--- a/main.go
+++ b/main.go
@@ -42,10 +42,10 @@ func main() {
 		rtpEnable              = kingpin.Flag("rtp.enable", "enable rtp info(feature:todo!), default: fasle").Default("false").Bool()
 		channelDurationDisable = kingpin.Flag(
 			"freeswitch.channel-duration.disable",
-			"Disable the freeswitch_channel_duration_seconds histogram of active channel ages.").Default("false").Bool()
-		channelDurationBucketsFlag = kingpin.Flag(
-			"freeswitch.channel-duration.buckets",
-			"Comma-separated histogram bucket upper bounds (seconds) for freeswitch_channel_duration_seconds.").Default("30,60,120,300,600,900,1800,3600,7200,14400,21600,43200,86400,172800").String()
+			"Disable the freeswitch_current_channels_by_duration gauge of active channel counts by age threshold.").Default("false").Bool()
+		channelDurationThresholdsFlag = kingpin.Flag(
+			"freeswitch.channel-duration.thresholds",
+			"Comma-separated, strictly increasing channel-age thresholds in seconds for freeswitch_current_channels_by_duration.").Default("21600,43200,86400").String()
 	)
 	kingpin.Version("freeswitch_exporter\nversion: 1.0.6")
 	kingpin.Parse()
@@ -58,10 +58,10 @@ func main() {
 	}
 	logger := promlog.New(promlogConfig)
 
-	channelDurationThresholds, err := parseThresholds(*channelDurationBucketsFlag)
+	channelDurationThresholds, err := parseThresholds(*channelDurationThresholdsFlag)
 
 	if err != nil {
-		panic(fmt.Sprintf("invalid --freeswitch.channel-duration.buckets: %v", err))
+		panic(fmt.Sprintf("invalid --freeswitch.channel-duration.thresholds: %v", err))
 	}
 
 	c, err := NewCollector(*scrapeURI, *timeout, *password, *rtpEnable, !*channelDurationDisable, channelDurationThresholds, logger)

--- a/main.go
+++ b/main.go
@@ -40,6 +40,12 @@ func main() {
 			"[EXPERIMENTAL] Path to config yaml file that can enable TLS or authentication.",
 		).Default("").String()
 		rtpEnable = kingpin.Flag("rtp.enable", "enable rtp info(feature:todo!), default: fasle").Default("false").Bool()
+		channelDurationEnable = kingpin.Flag(
+			"freeswitch.channel-duration.enable",
+			"Enable the freeswitch_channel_duration_seconds histogram of active channel ages.").Default("true").Bool()
+		channelDurationBucketsFlag = kingpin.Flag(
+			"freeswitch.channel-duration.buckets",
+			"Comma-separated histogram bucket upper bounds (seconds) for freeswitch_channel_duration_seconds.").Default("30,60,120,300,600,900,1800,3600,7200,14400,21600,43200,86400,172800").String()
 	)
 	kingpin.Version("freeswitch_exporter\nversion: 1.0.6")
 	kingpin.Parse()
@@ -52,7 +58,13 @@ func main() {
 	}
 	logger := promlog.New(promlogConfig)
 
-	c, err := NewCollector(*scrapeURI, *timeout, *password, *rtpEnable, logger)
+	channelDurationBuckets, err := parseBuckets(*channelDurationBucketsFlag)
+
+	if err != nil {
+		panic(fmt.Sprintf("invalid --freeswitch.channel-duration.buckets: %v", err))
+	}
+
+	c, err := NewCollector(*scrapeURI, *timeout, *password, *rtpEnable, *channelDurationEnable, channelDurationBuckets, logger)
 
 	if err != nil {
 		panic(err)
@@ -78,7 +90,7 @@ func main() {
 			target = fmt.Sprintf("tcp://%s", target)
 		}
 
-		c, colErr := NewCollector(target, *timeout, *password, *rtpEnable, logger)
+		c, colErr := NewCollector(target, *timeout, *password, *rtpEnable, *channelDurationEnable, channelDurationBuckets, logger)
 		if colErr != nil {
 			http.Error(w, fmt.Sprintf("failed to create collector for %s: %s", target, colErr), http.StatusInternalServerError)
 		}

--- a/main.go
+++ b/main.go
@@ -40,9 +40,9 @@ func main() {
 			"[EXPERIMENTAL] Path to config yaml file that can enable TLS or authentication.",
 		).Default("").String()
 		rtpEnable = kingpin.Flag("rtp.enable", "enable rtp info(feature:todo!), default: fasle").Default("false").Bool()
-		channelDurationEnable = kingpin.Flag(
-			"freeswitch.channel-duration.enable",
-			"Enable the freeswitch_channel_duration_seconds histogram of active channel ages.").Default("true").Bool()
+		channelDurationDisable = kingpin.Flag(
+			"freeswitch.channel-duration.disable",
+			"Disable the freeswitch_channel_duration_seconds histogram of active channel ages.").Default("false").Bool()
 		channelDurationBucketsFlag = kingpin.Flag(
 			"freeswitch.channel-duration.buckets",
 			"Comma-separated histogram bucket upper bounds (seconds) for freeswitch_channel_duration_seconds.").Default("30,60,120,300,600,900,1800,3600,7200,14400,21600,43200,86400,172800").String()
@@ -64,7 +64,7 @@ func main() {
 		panic(fmt.Sprintf("invalid --freeswitch.channel-duration.buckets: %v", err))
 	}
 
-	c, err := NewCollector(*scrapeURI, *timeout, *password, *rtpEnable, *channelDurationEnable, channelDurationBuckets, logger)
+	c, err := NewCollector(*scrapeURI, *timeout, *password, *rtpEnable, !*channelDurationDisable, channelDurationBuckets, logger)
 
 	if err != nil {
 		panic(err)
@@ -90,7 +90,7 @@ func main() {
 			target = fmt.Sprintf("tcp://%s", target)
 		}
 
-		c, colErr := NewCollector(target, *timeout, *password, *rtpEnable, *channelDurationEnable, channelDurationBuckets, logger)
+		c, colErr := NewCollector(target, *timeout, *password, *rtpEnable, !*channelDurationDisable, channelDurationBuckets, logger)
 		if colErr != nil {
 			http.Error(w, fmt.Sprintf("failed to create collector for %s: %s", target, colErr), http.StatusInternalServerError)
 		}

--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ func main() {
 			"Disable the freeswitch_current_channels_by_duration gauge of active channel counts by age threshold.").Default("false").Bool()
 		channelDurationThresholdsFlag = kingpin.Flag(
 			"freeswitch.channel-duration.thresholds",
-			"Comma-separated, strictly increasing channel-age thresholds in seconds for freeswitch_current_channels_by_duration.").Default("21600,43200,86400").String()
+			"Comma-separated, strictly increasing channel-age thresholds in seconds for freeswitch_current_channels_by_duration.").Default("30,60,120,300,600,900,1800,3600,7200,14400,21600,43200,86400,172800").String()
 	)
 	kingpin.Version("freeswitch_exporter\nversion: 1.0.6")
 	kingpin.Parse()


### PR DESCRIPTION
Adds a new gauge to track the duration of active FreeSWITCH channels at scrape time. 

* **How it works**: Parses `created_epoch` from the JSON channel list to calculate age in seconds.

### Why this is good
* **Detecting Deadlocks:** Catch zombie channels caused by FreeSWITCH bugs by setting up alerts for channels stuck over a certain threshold (e.g., >6h).
* **Fraud Detection:** Identify toll fraud or abandoned calls that stay connected indefinitely.
* **Traffic Profiling:** Analyze call duration distributions to better understand platform usage and plan for trunk capacity.
